### PR TITLE
Poc2app move gh client to class

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -19,6 +19,8 @@ func initCache() *appCache {
 	return &newCache
 }
 
+// TODO: unimplemented
+//lint:ignore U1000 uninpremented
 func (*appCache) save() error {
 	// save cache to disk, at predefined path
 	return nil

--- a/client.go
+++ b/client.go
@@ -54,7 +54,7 @@ func oauthCreateDeviceRequest() (*deviceOauthResponse, error) {
 }
 
 // TODO: Split two steps, bring User Interaction outside client class
-func (c *ghpClient) getOauthToken() error {
+func (c *ghpClient) performOauth() error {
 	device, err := oauthCreateDeviceRequest()
 	if err != nil {
 		return fmt.Errorf("error creating device request: %v", err)

--- a/client.go
+++ b/client.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+)
+
+type deviceOauthResponse struct {
+	DeviceCode      string `json:"device_code"`
+	UserCode        string `json:"user_code"`
+	VerificationURI string `json:"verification_uri"`
+	ExpiresIn       int    `json:"expires_in"`
+	Interval        int    `json:"interval"`
+}
+
+type oauthAuthCodeResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	Scope       string `json:"scope"`
+}
+
+type ghpClient struct {
+	oauthToken string
+}
+
+func oauthCreateDeviceRequest() (*deviceOauthResponse, error) {
+	body := strings.NewReader(`client_id=0412cc5fb93b10a59e50&scope=repo`)
+	req, err := http.NewRequest("POST", "https://github.com/login/device/code", body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	responseBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var responseJSON deviceOauthResponse
+	err = json.Unmarshal(responseBody, &responseJSON)
+	if err != nil {
+		return nil, err
+	}
+	return &responseJSON, nil
+}
+
+func getOauthToken(device *deviceOauthResponse) (*string, error) {
+	fmt.Println("A browser window will open")
+	fmt.Println("Please insert this code to authorize this client")
+	fmt.Println(device.UserCode)
+	openBrowser(device.VerificationURI)
+	fmt.Println("Press enter when done!")
+	fmt.Scanln() // wait for Enter Key
+
+	body := strings.NewReader(fmt.Sprintf("client_id=0412cc5fb93b10a59e50&device_code=%s&grant_type=urn:ietf:params:oauth:grant-type:device_code", device.DeviceCode))
+
+	req, err := http.NewRequest("POST", "https://github.com/login/oauth/access_token", body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	responseBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var responseAuth oauthAuthCodeResponse
+	err = json.Unmarshal(responseBody, &responseAuth)
+	if err != nil {
+		return nil, err
+	}
+	res := responseAuth.AccessToken
+	return &res, nil
+}
+
+func getOAuthToken() string {
+	res, err := oauthCreateDeviceRequest()
+	if err != nil {
+		log.Fatal("Error creating device request: ", err)
+	}
+
+	token, err := getOauthToken(res)
+	if err != nil {
+		log.Fatal("Error getting oauth token: ", err)
+	}
+	return *token
+}
+
+func createClient(authToken string) *ghpClient {
+	c := new(ghpClient)
+	c.oauthToken = authToken
+	return c
+}
+
+//lint:ignore U1000 uninpremented
+func (c *ghpClient) getToken() string {
+	return c.oauthToken
+}
+
+func (c *ghpClient) validToken() (bool, error) {
+	if c.oauthToken == "" {
+		log.Print("Empty token")
+		return false, nil
+	}
+	req, err := http.NewRequest("GET", "https://api.github.com/user", nil)
+	if err != nil {
+		return false, fmt.Errorf("error creating request: %v", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+	req.Header.Set("Authorization", "token "+c.oauthToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("error Sending request: %v", err)
+	}
+	defer resp.Body.Close()
+	_, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return false, fmt.Errorf("error reading body: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		return false, fmt.Errorf("client error: %v", resp.StatusCode)
+	}
+	return true, nil
+}

--- a/ghp.go
+++ b/ghp.go
@@ -50,10 +50,10 @@ func checkAllConfig(config *ghpConfig, client *ghpClient) {
 	}
 }
 
-func doList(state ghpConfig, cache *appCache, f filterFlags) {
+func doList(state ghpConfig, cache *appCache, client *ghpClient, f filterFlags) {
 	fmt.Printf("Requesting full project %v, this can take some time\n", state.DefaultProject)
 	p := new(ProjectProxy)
-	err := p.init(state, cache, state.DefaultProjectID)
+	err := p.init(state, cache, client, state.DefaultProjectID)
 	if err != nil {
 		fmt.Printf("Error creating client %v", err)
 	}
@@ -85,7 +85,7 @@ func main() {
 
 	if len(flag.Args()) < 2 {
 		checkAllConfig(state, client)
-		doList(*state, cache, filters)
+		doList(*state, cache, client, filters)
 		os.Exit(0)
 	}
 
@@ -147,7 +147,7 @@ func main() {
 		doHelp()
 	case "list":
 		checkAllConfig(state, client)
-		doList(*state, cache, filters)
+		doList(*state, cache, client, filters)
 	default:
 		fmt.Printf("Unsupported command %v\n\n", command)
 		doHelp()

--- a/ghp.go
+++ b/ghp.go
@@ -98,7 +98,7 @@ func main() {
 				os.Exit(0)
 			}
 		}
-		err := client.getOauthToken()
+		err := client.performOauth()
 		if err != nil {
 			fmt.Printf("Error Performing oauth: %v", err)
 			os.Exit(1)

--- a/ghp.go
+++ b/ghp.go
@@ -34,6 +34,7 @@ func doHelp() {
 	log.Fatal("Unimplemented")
 }
 
+// Checks config or exit with error and help text.
 func checkAllConfig(config *ghpConfig, client *ghpClient) {
 	valid, err := client.validToken()
 	if err != nil {

--- a/ghp.go
+++ b/ghp.go
@@ -34,6 +34,21 @@ func doHelp() {
 	log.Fatal("Unimplemented")
 }
 
+func checkAllConfig(config *ghpConfig, client *ghpClient) {
+	valid, err := client.validToken()
+	if err != nil {
+		fmt.Printf("There was a problem with the current stored token: %v", err)
+	}
+	if !valid {
+		fmt.Println("ghp is not configured yet, run 'ghp auth' and 'ghp config'")
+		os.Exit(1)
+	}
+	if config.DefaultProjectID == 0 {
+		fmt.Println("You don't have configured ghp yet, run 'ghp config'")
+		os.Exit(1)
+	}
+}
+
 func doList(state ghpConfig, cache *appCache, f filterFlags) {
 	fmt.Printf("Requesting full project %v, this can take some time\n", state.DefaultProject)
 	p := new(ProjectProxy)
@@ -68,18 +83,7 @@ func main() {
 	flag.Parse()
 
 	if len(flag.Args()) < 2 {
-		valid, err := client.validToken()
-		if err != nil {
-			fmt.Printf("There was a problem with the current stored token: %v", err)
-		}
-		if !valid {
-			fmt.Println("ghp is not configured yet, run 'ghp auth' and 'ghp config'")
-			os.Exit(1)
-		}
-		if state.DefaultProjectID == 0 {
-			fmt.Println("You don't have configured ghp yet, run 'ghp config'")
-			os.Exit(1)
-		}
+		checkAllConfig(state, client)
 		doList(*state, cache, filters)
 		os.Exit(0)
 	}
@@ -130,11 +134,7 @@ func main() {
 	case "help":
 		doHelp()
 	case "list":
-		valid, _ := client.validToken()
-		if !valid {
-			fmt.Printf("There's no valid oauth token, please run 'ghp auth'")
-			os.Exit(1)
-		}
+		checkAllConfig(state, client)
 		doList(*state, cache, filters)
 	default:
 		fmt.Printf("Unsupported command %v\n\n", command)

--- a/ghp.go
+++ b/ghp.go
@@ -99,7 +99,18 @@ func main() {
 				os.Exit(0)
 			}
 		}
-		err := client.performOauth()
+		userCode, oauthURI, err := client.prepareDeviceForOauth()
+		if err != nil {
+			fmt.Printf("Error Performing oauth: %v", err)
+			os.Exit(1)
+		}
+		fmt.Println("A browser window will open")
+		fmt.Println("Please insert this code to authorize this client")
+		fmt.Println(userCode)
+		openBrowser(oauthURI)
+		fmt.Println("Press enter when done!")
+		fmt.Scanln() // wait for Enter Key
+		err = client.performOauth()
 		if err != nil {
 			fmt.Printf("Error Performing oauth: %v", err)
 			os.Exit(1)

--- a/ghp.go
+++ b/ghp.go
@@ -94,8 +94,13 @@ func main() {
 				os.Exit(0)
 			}
 		}
-		state.AccessToken = getOAuthToken()
-		valid, err := client.validToken()
+		err := client.getOauthToken()
+		if err != nil {
+			fmt.Printf("Error Performing oauth: %v", err)
+			os.Exit(1)
+		}
+		state.AccessToken = client.getToken()
+		valid, err = client.validToken()
 		if err != nil {
 			fmt.Printf("Error whith token: %v", err)
 			os.Exit(1)

--- a/project.go
+++ b/project.go
@@ -261,6 +261,7 @@ func (p *ProjectProxy) init(state ghpConfig, cache *appCache, projectID int64) e
 	return nil
 }
 
+//lint:ignore U1000 uninpremented
 func (p *ProjectProxy) listProject(filter [][]string) {
 	for _, col := range p.columns {
 		fmt.Println(col.name + ":")

--- a/project.go
+++ b/project.go
@@ -18,10 +18,10 @@ type card interface {
 }
 
 type issue struct {
-	url        string
-	createdAt  github.Timestamp
-	ghIssue    *github.Issue
-	labels     []*github.Label
+	url       string
+	createdAt github.Timestamp
+	ghIssue   *github.Issue
+	//labels     []*github.Label
 	repository *github.Repository
 }
 
@@ -155,17 +155,17 @@ func (c *column) pullCards(p *ProjectProxy) error {
 	// log.Printf("pullig cards for %v", c.id)
 	cards, res, err := p.client.Projects.ListProjectCards(*p.context, c.id, nil)
 	if err != nil {
-		return fmt.Errorf("Error Getting cards for %v: %v", c.id, err)
+		return fmt.Errorf("error Getting cards for %v: %v", c.id, err)
 	}
 	if res.StatusCode != 200 {
-		return fmt.Errorf("Error Getting cards for %v: http: %v", c.id, res.Status)
+		return fmt.Errorf("error Getting cards for %v: http: %v", c.id, res.Status)
 	}
 	for _, card := range cards {
 		if !card.GetArchived() {
 			newCard, err := buildCard(p, card)
 			// log.Printf("new Card: %+v", newCard)
 			if err != nil {
-				return fmt.Errorf("Error Getting card for %v: %v", c.id, err)
+				return fmt.Errorf("error Getting card for %v: %v", c.id, err)
 			}
 			c.cards = append(c.cards, newCard)
 		}
@@ -195,7 +195,7 @@ func (p *ProjectProxy) requestAPI(url string, v interface{}) error {
 		return err
 	}
 	if res.StatusCode != 200 {
-		return fmt.Errorf("Error Getting %v: %v", url, res.Status)
+		return fmt.Errorf("error getting %v: %v", url, res.Status)
 	}
 	p.cache.add(url, v)
 	// TODO: process API response
@@ -224,13 +224,13 @@ func (p *ProjectProxy) pullColums(projectID int64) error {
 	// log.Printf("Pull columns %v", projectID)
 	cols, res, err := p.client.Projects.ListProjectColumns(*p.context, projectID, nil)
 	if err != nil {
-		return fmt.Errorf("Error Getting columns for %v: %v", projectID, err)
+		return fmt.Errorf("error getting columns for %v: %v", projectID, err)
 	}
 	if res.StatusCode != 200 {
-		return fmt.Errorf("Error Getting columns for %v: http: %v", projectID, res.Status)
+		return fmt.Errorf("error getting columns for %v: http: %v", projectID, res.Status)
 	}
 	if len(cols) < 1 {
-		return fmt.Errorf("Error Getting columns for %v: Zero items", projectID)
+		return fmt.Errorf("error getting columns for %v: Zero items", projectID)
 	}
 	for _, c := range cols {
 		col := new(column)

--- a/utils.go
+++ b/utils.go
@@ -16,19 +16,19 @@ func choice(prompt string, choices []string) (int, error) {
 	reader := bufio.NewReader(os.Stdin)
 	response, err := reader.ReadString('\n')
 	if err != nil {
-		return 0, fmt.Errorf("Error reading choice")
+		return 0, fmt.Errorf("error reading choice")
 	}
 	response = strings.ToLower(strings.TrimSpace(response))
 	if response == "exit" {
-		return 0, fmt.Errorf("Aborted by user")
+		return 0, fmt.Errorf("aborted by user")
 	}
 
 	index, err := strconv.Atoi(response)
 	if err != nil {
-		return 0, fmt.Errorf("Invalid input: %v", err)
+		return 0, fmt.Errorf("invalid input: %v", err)
 	}
 	if index == 0 || index > len(choices) {
-		return 0, fmt.Errorf("Invalid input: %v", index)
+		return 0, fmt.Errorf("invalid input: %v", index)
 	}
 	return index - 1, nil
 }


### PR DESCRIPTION
In order to expand the functionality the cache api client must be used by and not belong to project class. This PR separates the project and the main app from the oauth client and API client, moving all the functionality to a new ghpClient class